### PR TITLE
Make DispatchRider::Publisher#configure indifferent to string or symbol ...

### DIFF
--- a/lib/dispatch-rider/publisher.rb
+++ b/lib/dispatch-rider/publisher.rb
@@ -1,10 +1,12 @@
+require "active_support/core_ext/hash/indifferent_access"
+
 # This class takes care of the publishing side of the messaging system.
 module DispatchRider
   class Publisher
     attr_reader :service_channel_mapper, :notification_service_registrar, :publishing_destination_registrar, :sns_channel_registrar
 
     def configure(configuration_hash = {})
-      ConfigurationReader.parse(configuration_hash, self)
+      ConfigurationReader.parse(configuration_hash.with_indifferent_access, self)
     end
 
     def initialize

--- a/spec/lib/dispatch-rider/publisher_spec.rb
+++ b/spec/lib/dispatch-rider/publisher_spec.rb
@@ -30,7 +30,7 @@ describe DispatchRider::Publisher do
     end
 
     it "calls config reader" do
-      DispatchRider::Publisher::ConfigurationReader.should_receive(:parse).with(configuration_hash, subject)
+      DispatchRider::Publisher::ConfigurationReader.should_receive(:parse).with(configuration_hash.with_indifferent_access, subject)
       subject.configure(configuration_hash)
     end
   end


### PR DESCRIPTION
This allows DispatchRider::Publisher#configure accept either string or symbol keys on the configuration.

Needed for systems that could not serialize symbols into the configuration file, eg. JSON. 
