### PR TITLE
Silence SQS spam since its very verbose by default

### DIFF
--- a/lib/dispatch-rider/queue_services/aws_sqs.rb
+++ b/lib/dispatch-rider/queue_services/aws_sqs.rb
@@ -7,7 +7,7 @@ module DispatchRider
 
       def assign_storage(attrs)
         begin
-          AWS::SQS.new.queues.named(attrs.fetch(:name))
+          AWS::SQS.new(:logger => nil).queues.named(attrs.fetch(:name))
         rescue NameError
           raise AdapterNotFoundError.new(self.class.name, 'aws-sdk')
         rescue IndexError


### PR DESCRIPTION
Silence SQS spam since its very verbose by default

This is an intermediate fix until DR has an internal logger object we can better purpose for this job.
