### PR TITLE
Assume successful process when there is no error

### DIFF
--- a/lib/dispatch-rider/dispatcher.rb
+++ b/lib/dispatch-rider/dispatcher.rb
@@ -21,6 +21,7 @@ module DispatchRider
 
     def dispatch(message)
       handler_registrar.fetch(message.subject).process(message.body)
+      true # success => true (delete message)
     rescue Exception => exception
       @error_handler.call(message, exception)
     end

--- a/spec/lib/dispatch-rider/dispatcher_spec.rb
+++ b/spec/lib/dispatch-rider/dispatcher_spec.rb
@@ -9,6 +9,14 @@ describe DispatchRider::Dispatcher, :nodb => true do
     end
   end
 
+  module HandlerThatReturnsFalse
+    class << self
+      def process(params)
+        false
+      end
+    end
+  end
+
   module FailHandling
     class << self
       def process(params)
@@ -27,6 +35,18 @@ describe DispatchRider::Dispatcher, :nodb => true do
 
       it "should process the message" do
         expect { subject.dispatch(message) }.to throw_symbol(:something)
+      end
+    end
+
+    context "when the handler returns false" do
+      let(:message){ DispatchRider::Message.new(:subject => "handler_that_returns_false", :body => { :do_throw_something => true }) }
+
+      before :each do
+        subject.register('handler_that_returns_false')
+      end
+
+      it "should return true indicating message is good to be removed" do
+        subject.dispatch(message).should be_true
       end
     end
 


### PR DESCRIPTION
This makes the dispatcher assume the message handling is successful if there's no error.
