### PR TITLE
Added process naming to dispatcher.

### DIFF
--- a/lib/dispatch-rider/dispatcher.rb
+++ b/lib/dispatch-rider/dispatcher.rb
@@ -2,9 +2,13 @@
 # The handlers must be registered with the dispatcher.
 # Tha handlers need to be modules that implement the process method.
 # What handler to dispatch the message to is figured out from the subject of the message.
+
 module DispatchRider
   class Dispatcher
     extend Forwardable
+
+    require 'dispatch-rider/dispatcher/named_process'
+    include NamedProcess
 
     attr_reader :handler_registrar
 
@@ -20,7 +24,10 @@ module DispatchRider
     end
 
     def dispatch(message)
-      handler_registrar.fetch(message.subject).process(message.body)
+      with_named_process(message.subject) do
+        handler_registrar.fetch(message.subject).process(message.body)
+      end
+
       true # success => true (delete message)
     rescue Exception => exception
       @error_handler.call(message, exception)

--- a/lib/dispatch-rider/dispatcher/named_process.rb
+++ b/lib/dispatch-rider/dispatcher/named_process.rb
@@ -1,0 +1,13 @@
+module DispatchRider
+  module Dispatcher::NamedProcess
+    def with_named_process(subject)
+      original_program_name = $0
+      begin
+        $0 += " - #{subject}"
+        yield
+      ensure
+        $0 = original_program_name
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the handler name to the process name so you can view which handler is currently running using ps or top or whatever. Once the job is finished, it will set the process name back to dispatchrider.id.
