### PR TITLE
Fail job after running error handler.

### DIFF
--- a/lib/dispatch-rider/dispatcher.rb
+++ b/lib/dispatch-rider/dispatcher.rb
@@ -31,6 +31,7 @@ module DispatchRider
       true # success => true (delete message)
     rescue Exception => exception
       @error_handler.call(message, exception)
+      false # failure => false (put message back on queue)
     end
 
     private


### PR DESCRIPTION
Simply returns false when the job fails.
