### PR TITLE
Catch only standard error exceptions.

### DIFF
--- a/lib/dispatch-rider/demultiplexer.rb
+++ b/lib/dispatch-rider/demultiplexer.rb
@@ -18,7 +18,7 @@ module DispatchRider
       do_loop do
         begin
           handle_next_queue_item
-        rescue Exception => exception
+        rescue => exception
           error_handler.call(Message.new(subject: "TopLevelError", body: {}), exception)
           throw :done
         end
@@ -34,7 +34,7 @@ module DispatchRider
 
     def dispatch_message(message)
       dispatcher.dispatch(message)
-    rescue Exception => exception
+    rescue => exception
       error_handler.call(message, exception)
     end
 


### PR DESCRIPTION
This will make the demultiplexer only catch StandardError exceptions rather than all exceptions, so that exceptions like SystemExit, NoMemoryError and ScriptError won't be handled by the error handler.
