### PR TITLE
Moving message id code to Publisher itself (not publisher base) to make it happen simply every time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
   - "2.0.0"
-  - "2.1.2"
+  - "2.1.5"
+  - "2.2.1"
 script: "bundle exec rspec"

--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,5 @@ group :development, :test do
 end
 
 group :test do
-  gem "aws-sdk"
+  gem "aws-sdk", "~> 1"
 end

--- a/lib/dispatch-rider/publisher.rb
+++ b/lib/dispatch-rider/publisher.rb
@@ -35,8 +35,23 @@ module DispatchRider
 
     def publish(opts = {})
       options = opts.dup
+      add_message_id(options[:message])
       service_channel_mapper.map(options.delete(:destinations)).each do |(service, channels)|
         notification_service_registrar.fetch(service).publish(options.merge(:to => channels))
+      end
+    end
+
+    private
+
+    def add_message_id(message)
+      message[:body][:guid] = generate_new_message_id
+    end
+
+    def generate_new_message_id
+      if DispatchRider.config.debug
+        DispatchRider::Debug::PUBLISHER_MESSAGE_GUID
+      else
+        SecureRandom.uuid
       end
     end
 

--- a/lib/dispatch-rider/publisher/base.rb
+++ b/lib/dispatch-rider/publisher/base.rb
@@ -21,16 +21,6 @@ module DispatchRider
         raise NotImplementedError
       end
 
-      private
-
-      def generate_new_message_id
-        if DispatchRider.config.debug
-          DispatchRider::Debug::PUBLISHER_MESSAGE_GUID
-        else
-          SecureRandom.uuid
-        end
-      end
-
     end
 
     def initialize(publisher = nil)
@@ -39,9 +29,6 @@ module DispatchRider
 
     def publish(body)
       raise ArgumentError, 'body should be a hash' unless body.kind_of?(Hash)
-      body = body.merge({
-        'guid' => generate_new_message_id,
-      })
       publisher.publish(destinations: destinations, message: { subject: subject, body: body })
     end
 
@@ -55,12 +42,6 @@ module DispatchRider
 
     def subject
       self.class.instance_variable_get(:@subject)
-    end
-
-    private
-
-    def generate_new_message_id
-      self.class.send(:generate_new_message_id)
     end
 
   end

--- a/spec/lib/dispatch-rider/publisher/base_spec.rb
+++ b/spec/lib/dispatch-rider/publisher/base_spec.rb
@@ -35,15 +35,6 @@ describe DispatchRider::Publisher::Base do
       end
     end
 
-    around do |ex|
-      begin
-        DispatchRider.config.debug = true
-        ex.call
-      ensure
-        DispatchRider.config.debug = false
-      end
-    end
-
     context "in a derived class with publish implemented" do
       let(:message) do
         {
@@ -52,7 +43,6 @@ describe DispatchRider::Publisher::Base do
             subject: "Loud Cheering",
             body: {
               "bla" => "WOOOOOOOO!",
-              "guid" => DispatchRider::Debug::PUBLISHER_MESSAGE_GUID,
             }
           }
         }
@@ -72,7 +62,6 @@ describe DispatchRider::Publisher::Base do
             subject: "Ferocious Tigers!",
             body: {
               "bla" => "RAAAAAWWWWW!",
-              "guid" => DispatchRider::Debug::PUBLISHER_MESSAGE_GUID,
             },
           }
         }


### PR DESCRIPTION
**Feature:**
This refactors out the uuid assigned to messages to not happen at Publisher::Base (which is slowly dying in favor of self publishing handlers) and to happen transparently as part of Publisher (the actual core service) and get just added to all messages.

**Ticket:**
Loosely related to https://app.asana.com/0/28536505712758/27321449891816 came about as part of a refactor and a bug I noticed, a recent refactor of PublishingSupport in core actually broke the uuid support :(

**Submitter Checklist:**
- [x] CI Passing
- [x] PR Linked to Asana Ticket
- [x] Hound Appeased Acceptably
- [x] No Code Climate Issues
- [x] Class, Module, and public method comments up to spec

**Reviewer Checklist:**
- [x] New Code Tested Effectively
- [x] Code organization meets SOP standards
- [x] Does this code fullfill the ticket?

**Only Then:**
- [ ] Move ticket in Asana