### PR TITLE
Fix Rspec warnings: deprecated use of "its" (use a separate gem instead)...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ end
 
 group :development, :test do
   gem "rspec", "~> 2.0"
+  gem 'rspec-its', "~> 1.0"
   gem "byebug", platform: :ruby_20, require: !ENV['CI']
 end
 

--- a/spec/lib/dispatch-rider/dispatcher_spec.rb
+++ b/spec/lib/dispatch-rider/dispatcher_spec.rb
@@ -62,7 +62,7 @@ describe DispatchRider::Dispatcher, :nodb => true do
       end
 
       it "should return true indicating message is good to be removed" do
-        subject.dispatch(message).should be_true
+        expect(subject.dispatch(message)).to be true
       end
     end
   end

--- a/spec/lib/dispatch-rider/notification_services/base_spec.rb
+++ b/spec/lib/dispatch-rider/notification_services/base_spec.rb
@@ -14,7 +14,7 @@ describe DispatchRider::NotificationServices::Base do
   before :each do
     DispatchRider::NotificationServices::Base.any_instance.stub(:notifier_builder).and_return(OpenStruct)
     DispatchRider::NotificationServices::Base.any_instance.stub(:channel_registrar_builder).and_return(DispatchRider::Registrars::SnsChannel)
-    DispatchRider::NotificationServices::Base.any_instance.stub(:channel).and_return do |name|
+    DispatchRider::NotificationServices::Base.any_instance.stub(:channel) do |name|
       subject.notifier.topics[subject.fetch(name)] if name == :foo
     end
   end

--- a/spec/lib/dispatch-rider/publisher/configuration/destination_spec.rb
+++ b/spec/lib/dispatch-rider/publisher/configuration/destination_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rspec/its'
 
 describe DispatchRider::Publisher::Configuration::Destination do
 
@@ -21,19 +22,19 @@ describe DispatchRider::Publisher::Configuration::Destination do
   subject{ described_class.new("employee", attributes) }
 
   describe "#name" do
-    its(:name){ should == "employee" }
+    its(:name) { is_expected.to eq("employee") }
   end
 
   describe "#service" do
-    its(:service){ should == "aws_sns" }
+    its(:service) { is_expected.to eq("aws_sns") }
   end
 
   describe "#channel" do
-    its(:channel){ should == "employee_updates" }
+    its(:channel) { is_expected.to eq("employee_updates") }
   end
 
   describe "#options" do
-    its(:options){ should == options }
+    its(:options) { is_expected.to eq(options) }
   end
 
   describe "#==" do

--- a/spec/lib/dispatch-rider/queue_services/base_spec.rb
+++ b/spec/lib/dispatch-rider/queue_services/base_spec.rb
@@ -115,7 +115,7 @@ describe DispatchRider::QueueServices::Base do
 
   describe "#empty?" do
     before :each do
-      base_queue.stub(:size).and_return { base_queue.queue.size }
+      base_queue.stub(:size) { base_queue.queue.size }
     end
 
     context "when the queue is empty" do

--- a/spec/lib/dispatch-rider/registrars/base_spec.rb
+++ b/spec/lib/dispatch-rider/registrars/base_spec.rb
@@ -25,7 +25,7 @@ describe DispatchRider::Registrars::Base do
 
     context "when there is a missing constant while registering" do
       it "raises an exception" do
-        subject.should_receive(:value).with(:foo, {}).and_return { 'bar'.camelize.constantize }
+        subject.should_receive(:value).with(:foo, {}) { 'bar'.camelize.constantize }
         expect { subject.register(:foo) }.to raise_exception(DispatchRider::NotFound)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,9 @@ RSpec.configure do |config|
   config.order = 'random'
   config.color = true
   config.tty = true
+  config.mock_with :rspec do |mocks|
+    mocks.yield_receiver_to_any_instance_implementation_blocks = false
+  end
 end
 
 # Airbrake dummy module


### PR DESCRIPTION
..., new syntax for "and_return" method, new configuration for stubing methods on any instance of the class.