### PR TITLE
Make the overriden function "publish to channel" be the only thing overriden

### DIFF
--- a/lib/dispatch-rider/notification_services/aws_sns.rb
+++ b/lib/dispatch-rider/notification_services/aws_sns.rb
@@ -16,12 +16,8 @@ module DispatchRider
         Registrars::SnsChannel
       end
 
-      def publish(options)
-        channels(options[:to]).each do |channel|
-          with_retries(max_retries: 10, rescue: AWS::Errors::MissingCredentialsError) do
-            channel.publish(serialize(options[:message]))
-          end
-        end
+      def publish_to_channel(channel, message:)
+        with_retries(max_retries: 10, rescue: AWS::Errors::MissingCredentialsError) { super }
       end
 
       # not really happy with this, but the notification service registrar system is way too rigid to do this cleaner

--- a/lib/dispatch-rider/notification_services/base.rb
+++ b/lib/dispatch-rider/notification_services/base.rb
@@ -28,10 +28,8 @@ module DispatchRider
         raise NotImplementedError
       end
 
-      def publish(options)
-        channels(options[:to]).each do |channel|
-          channel.publish(serialize(options[:message]))
-        end
+      def publish(to:, message:)
+        channels(to).each { |channel| publish_to_channel channel, message: message }
       end
 
       def channels(names)
@@ -40,6 +38,10 @@ module DispatchRider
 
       def channel(name)
         raise NotImplementedError
+      end
+
+      def publish_to_channel(channel, message:)
+        channel.publish(serialize(message))
       end
 
       private

--- a/spec/lib/dispatch-rider/notification_services/aws_sns_spec.rb
+++ b/spec/lib/dispatch-rider/notification_services/aws_sns_spec.rb
@@ -15,6 +15,23 @@ describe DispatchRider::NotificationServices::AwsSns do
     end
   end
 
+  describe "#publish_to_channel" do
+    let(:channel) { double(:channel) }
+    let(:message) { DispatchRider::Message.new(subject: :test_handler, body: { "bar" => "baz" }) }
+
+    # @note: This is tested this way cause you don't really wanna post a message to the actual service.
+    it "publishes the message to the channels" do
+      expect(channel).to receive(:publish).with(kind_of String) { |serialized_message|
+        expect(JSON.parse(serialized_message)).to eq(
+          "subject" => "test_handler",
+          "body" => { "bar" => "baz" }
+        )
+      }
+
+      subject.publish_to_channel(channel, message: message)
+    end
+  end
+
   describe "#channel" do
     before { subject.stub(:channel_registrar).and_return(foo: amazon_resource_name) }
 


### PR DESCRIPTION
**Feature:**
This will remove the trap when changing the base class of a notification service.

**Ticket:**
https://app.asana.com/0/31201157368385/31666554967885

**Submitter Checklist:**
- [ ] CI Passing
- [ ] PR Linked to Asana Ticket
- [ ] Hound Appeased Acceptably
- [ ] No Code Climate Issues
- [ ] Class, Module, and public method comments up to spec

**Reviewer Checklist:**
- [x] New Code Tested Effectively
- [x] Code organization meets SOP standards
- [x] Does this code fullfill the ticket?

**Only Then:**
- [x] Move ticket in Asana